### PR TITLE
[TGER] migrated missing nova filter from nova resource, Voucher

### DIFF
--- a/src/Nova/Voucher.php
+++ b/src/Nova/Voucher.php
@@ -47,7 +47,7 @@ class Voucher extends BaseResource
 
     /** @psalm-suppress UndefinedClass */
     protected array $filterClassList = [
-
+        \Tipoff\Locations\Nova\Filters\OrderLocation::class,
     ];
 
     public function fieldsForIndex(NovaRequest $request)

--- a/tests/Unit/Models/VoucherModelTest.php
+++ b/tests/Unit/Models/VoucherModelTest.php
@@ -92,7 +92,7 @@ class VoucherModelTest extends TestCase
 
         $voucher->generateCode()->save();
 
-        $this->assertStringStartsWith(Carbon::now()->format('ymd'), $voucher->code);
+        $this->assertStringStartsWith(Carbon::now('America/New_York')->format('ymd'), $voucher->code);
     }
 
     /** @test */


### PR DESCRIPTION
close #28 

migrated nova filter OrderLocation into nova resource Voucher in filterClassList[]

-same error as branch Omnia/feature/#59 migrate nova resources
  but it was still merged

> - tipoff/taxes dev-main requires tipoff/support 1.2.7 -> found tipoff/support[1.2.7] but it conflicts with your root composer.json require (^1.3.0).
> - tipoff/checkout 2.0.1 requires tipoff/taxes dev-main -> satisfiable by tipoff/taxes[dev-main].
> - Root composer.json requires tipoff/checkout ^2.0.1 -> satisfiable by tipoff/checkout[2.0.1].