### PR TITLE
Add createRefundVoucher and new source field in vouchers table

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "tipoff/addresses": "^2.4.3",
-        "tipoff/authorization": "^2.5.4",
-        "tipoff/checkout": "^2.4.2",
-        "tipoff/support": "^1.6.2"
+        "tipoff/addresses": "^2.5.0",
+        "tipoff/authorization": "^2.5.5",
+        "tipoff/checkout": "^2.5.0",
+        "tipoff/support": "^1.6.5"
     },
     "require-dev": {
         "tipoff/test-support": "^1.2.0"

--- a/database/factories/VoucherFactory.php
+++ b/database/factories/VoucherFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tipoff\Vouchers\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Tipoff\Vouchers\Enums\VoucherSource;
 use Tipoff\Vouchers\Models\Voucher;
 use Tipoff\Vouchers\Models\VoucherType;
 
@@ -32,11 +33,14 @@ class VoucherFactory extends Factory
             $participants = $this->faker->numberBetween(1, 10);
         }
 
+        $source = $this->faker->randomElement(VoucherSource::getEnumerators());
+
         return [
             'code'              => $this->faker->md5,
-            'user_id'       => randomOrCreate(app('user')),
+            'user_id'           => randomOrCreate(app('user')),
             'location_id'       => randomOrCreate(app('location')),
-            'voucher_type_id'   => randomOrCreate(VoucherType::class),
+            'source'            => $source,
+            'voucher_type_id'   => $source->is(VoucherSource::PURCHASE()) ? randomOrCreate(VoucherType::class) : null,
             'purchase_order_id' => randomOrCreate(app('order')),
             'order_id'          => randomOrCreate(app('order')),
             'amount'            => $amount,
@@ -108,4 +112,13 @@ class VoucherFactory extends Factory
         });
     }
 
+    public function source(VoucherSource $source): self
+    {
+        return $this->state(function (array $attributes) use ($source) {
+            return [
+                'source'            => $source,
+                'voucher_type_id'   => $source->is(VoucherSource::PURCHASE()) ? randomOrCreate(VoucherType::class) : null,
+            ];
+        });
+    }
 }

--- a/database/migrations/2020_05_06_150000_create_vouchers_table.php
+++ b/database/migrations/2020_05_06_150000_create_vouchers_table.php
@@ -19,7 +19,8 @@ class CreateVouchersTable extends Migration
             // Purchase fields
             $table->foreignIdFor(app('user'));
             $table->foreignIdFor(app('location'));
-            $table->foreignIdFor(VoucherType::class);
+            $table->string('source');
+            $table->foreignIdFor(VoucherType::class)->nullable();
             $table->foreignIdFor(Order::class, 'purchase_order_id')->nullable();
 
             // Redemption fields

--- a/src/Enums/VoucherSource.php
+++ b/src/Enums/VoucherSource.php
@@ -14,7 +14,7 @@ use Tipoff\Support\Enums\BaseEnum;
  */
 class VoucherSource extends BaseEnum
 {
-    const REFUND             = 'refund';
+    const REFUND = 'refund';
     const PARTIAL_REDEMPTION = 'partial_redemption';
-    const PURCHASE           = 'purchase';
+    const PURCHASE = 'purchase';
 }

--- a/src/Enums/VoucherSource.php
+++ b/src/Enums/VoucherSource.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Vouchers\Enums;
+
+use Tipoff\Support\Enums\BaseEnum;
+
+/**
+ * @method static VoucherSource REFUND()
+ * @method static VoucherSource PARTIAL_REDEMPTION()
+ * @method static VoucherSource PURCHASE()
+ * @psalm-immutable
+ */
+class VoucherSource extends BaseEnum
+{
+    const REFUND             = 'refund';
+    const PARTIAL_REDEMPTION = 'partial_redemption';
+    const PURCHASE           = 'purchase';
+}

--- a/src/Listeners/OrderCreatedListener.php
+++ b/src/Listeners/OrderCreatedListener.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use Tipoff\Checkout\Models\Cart;
 use Tipoff\Checkout\Models\Order;
 use Tipoff\Support\Events\Checkout\OrderCreated;
+use Tipoff\Vouchers\Enums\VoucherSource;
 use Tipoff\Vouchers\Models\Voucher;
 use Tipoff\Vouchers\Notifications\PartialRedemptionVoucherCreated;
 
@@ -47,7 +48,7 @@ class OrderCreatedListener
 
             $voucher = new Voucher;
             $voucher->amount = $unusedVoucherAmount;
-            $voucher->voucher_type_id = Voucher::PARTIAL_REDEMPTION_VOUCHER_TYPE_ID;
+            $voucher->source = VoucherSource::PARTIAL_REDEMPTION();
             $voucher->location_id = $order->getLocationId();
             $voucher->expires_at = $vouchers->min->expires_at;
             $voucher->redeemable_at = Carbon::now();

--- a/src/Listeners/OrderItemCreatedListener.php
+++ b/src/Listeners/OrderItemCreatedListener.php
@@ -7,6 +7,7 @@ namespace Tipoff\Vouchers\Listeners;
 use Carbon\Carbon;
 use Tipoff\Checkout\Models\OrderItem;
 use Tipoff\Support\Events\Checkout\OrderItemCreated;
+use Tipoff\Vouchers\Enums\VoucherSource;
 use Tipoff\Vouchers\Models\Voucher;
 use Tipoff\Vouchers\Models\VoucherType;
 use Tipoff\Vouchers\Notifications\VoucherCreated;
@@ -32,6 +33,7 @@ class OrderItemCreatedListener
         $user = $orderItem->order->user;
 
         $voucher = new Voucher;
+        $voucher->source = VoucherSource::PURCHASE();
         $voucher->amount = $voucherType->amount;
         $voucher->participants = $voucherType->participants;
         $voucher->voucher_type_id = $voucherType->id;

--- a/src/Models/Voucher.php
+++ b/src/Models/Voucher.php
@@ -88,7 +88,7 @@ class Voucher extends BaseModel implements VoucherInterface
 
             Assert::lazy()
                 ->that(empty($voucher->amount) && empty($voucher->participants), 'amount')->false('A voucher must have either an amount or number of participants.')
-                ->that(!empty($voucher->amount) && !empty($voucher->participants), 'amount')->false('A voucher cannot have both an amount & number of participants.')
+                ->that(! empty($voucher->amount) && ! empty($voucher->participants), 'amount')->false('A voucher cannot have both an amount & number of participants.')
                 ->verifyNow();
         });
     }
@@ -169,7 +169,7 @@ class Voucher extends BaseModel implements VoucherInterface
      */
     public function isValidAt($date): bool
     {
-        if (!$date instanceof Carbon) {
+        if (! $date instanceof Carbon) {
             $date = new Carbon($date);
         }
 
@@ -181,7 +181,7 @@ class Voucher extends BaseModel implements VoucherInterface
             return false;
         }
 
-        if (!empty($this->redeemed_at)) {
+        if (! empty($this->redeemed_at)) {
             return false;
         }
 

--- a/src/Nova/Voucher.php
+++ b/src/Nova/Voucher.php
@@ -14,6 +14,8 @@ use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;
+use Tipoff\Support\Nova\Fields\Enum;
+use Tipoff\Vouchers\Enums\VoucherSource;
 
 class Voucher extends BaseResource
 {
@@ -56,6 +58,7 @@ class Voucher extends BaseResource
             ID::make()->sortable(),
             Text::make('Code')->sortable(),
             nova('user') ? BelongsTo::make('User', 'user', nova('user'))->sortable() : null,
+            Enum::make('Source', 'source')->attach(VoucherSource::class),
             nova('voucher') ? BelongsTo::make('Voucher Type', 'voucher_type', nova('voucher'))->sortable() : null,
             nova('location') ? BelongsTo::make('Location', 'location', nova('location'))->sortable() : null,
             Date::make('Created At')->sortable(),
@@ -69,6 +72,7 @@ class Voucher extends BaseResource
         return array_filter([
             Text::make('Code')->exceptOnForms(),
             nova('user') ? BelongsTo::make('User', 'user', nova('user'))->searchable()->withSubtitles()->hideWhenUpdating() : null,
+            Enum::make('Source', 'source')->attach(VoucherSource::class),
             nova('vouchertype') ? BelongsTo::make('Voucher Type', 'voucher_type', nova('vouchertype'))->hideWhenUpdating() : null,
             nova('location') ? BelongsTo::make('Location', 'location', nova('location'))->hideWhenUpdating() : null,
             nova('order') ? BelongsTo::make('Purchase Order', 'purchaseOrder', nova('order'))->exceptOnForms() : null,

--- a/src/Transformers/VoucherTransformer.php
+++ b/src/Transformers/VoucherTransformer.php
@@ -32,6 +32,6 @@ class VoucherTransformer extends BaseTransformer
 
     public function includeVoucherType(Voucher $voucher)
     {
-        return $this->item($voucher->voucher_type, new VoucherTypeTransformer());
+        return $voucher->voucher_type ? $this->item($voucher->voucher_type, new VoucherTypeTransformer()) : null;
     }
 }

--- a/src/Transformers/VoucherTransformer.php
+++ b/src/Transformers/VoucherTransformer.php
@@ -20,7 +20,8 @@ class VoucherTransformer extends BaseTransformer
     {
         return [
             'id' => $voucher->id,
-            'name' => $voucher->voucher_type->name,
+            'source' => $voucher->source->getValue(),
+            'name' => $voucher->voucher_type ? $voucher->voucher_type->name : null,
             'code' => $voucher->code,
             'amount' => $voucher->amount,
             'participants' => $voucher->participants,

--- a/tests/Unit/Http/Controllers/Api/VoucherControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/VoucherControllerTest.php
@@ -7,6 +7,7 @@ namespace Tipoff\Vouchers\Tests\Unit\Http\Controllers\Api;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Symfony\Component\HttpFoundation\Response;
 use Tipoff\Authorization\Models\User;
+use Tipoff\Vouchers\Enums\VoucherSource;
 use Tipoff\Vouchers\Models\Voucher;
 use Tipoff\Vouchers\Tests\TestCase;
 
@@ -61,7 +62,7 @@ class VoucherControllerTest extends TestCase
         /** @var User $user */
         $user = User::factory()->create();
         /** @var Voucher $voucher */
-        $voucher = Voucher::factory()->create([
+        $voucher = Voucher::factory()->source(VoucherSource::PURCHASE())->create([
             'user_id' => $user,
         ]);
 

--- a/tests/Unit/Listeners/OrderCreatedListenerTest.php
+++ b/tests/Unit/Listeners/OrderCreatedListenerTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Notification;
 use Tipoff\Checkout\Models\Cart;
 use Tipoff\Checkout\Models\Order;
 use Tipoff\Support\Events\Checkout\OrderCreated;
+use Tipoff\Vouchers\Enums\VoucherSource;
 use Tipoff\Vouchers\Listeners\OrderCreatedListener;
 use Tipoff\Vouchers\Models\Voucher;
 use Tipoff\Vouchers\Notifications\PartialRedemptionVoucherCreated;
@@ -84,7 +85,7 @@ class OrderCreatedListenerTest extends TestCase
         ]);
 
         /** @var Voucher $voucher */
-        $voucher = Voucher::factory()->expired(false)->amount(1000)->create();
+        $voucher = Voucher::factory()->expired(false)->amount(1000)->source(VoucherSource::PURCHASE())->create();
 
         /** @var Cart $cart */
         $cart = Cart::factory()->create();
@@ -101,7 +102,7 @@ class OrderCreatedListenerTest extends TestCase
 
         $vouchers = Voucher::query()
             ->where('user_id', '=', $voucher->getUser()->id)
-            ->where('voucher_type_id', '=', Voucher::PARTIAL_REDEMPTION_VOUCHER_TYPE_ID)
+            ->where('source', '=', VoucherSource::PARTIAL_REDEMPTION)
             ->get();
         $this->assertCount(1, $vouchers);
 

--- a/tests/Unit/Models/VoucherModelTest.php
+++ b/tests/Unit/Models/VoucherModelTest.php
@@ -385,7 +385,7 @@ class VoucherModelTest extends TestCase
         $voucher = Voucher::createRefundVoucher(123, $user, 1000);
         $this->assertEquals(VoucherSource::REFUND, $voucher->source->getValue());
         $this->assertEquals(1000, $voucher->amount);
-        $this->assertNull( $voucher->participants);
+        $this->assertNull($voucher->participants);
         $this->assertEquals($user->id, $voucher->user_id);
     }
 }

--- a/tests/Unit/Models/VoucherModelTest.php
+++ b/tests/Unit/Models/VoucherModelTest.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tipoff\Authorization\Models\User;
 use Tipoff\Checkout\Models\Cart;
+use Tipoff\Vouchers\Enums\VoucherSource;
 use Tipoff\Vouchers\Exceptions\UnsupportedVoucherTypeException;
 use Tipoff\Vouchers\Exceptions\VoucherRedeemedException;
 use Tipoff\Vouchers\Models\Voucher;
@@ -373,5 +374,18 @@ class VoucherModelTest extends TestCase
         $this->assertCount(2, $codes);
         $this->assertEquals($voucher1->code, $codes[0]->code);
         $this->assertEquals($voucher2->code, $codes[1]->code);
+    }
+
+    /** @test */
+    public function create_refund_voucher()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $voucher = Voucher::createRefundVoucher(123, $user, 1000);
+        $this->assertEquals(VoucherSource::REFUND, $voucher->source->getValue());
+        $this->assertEquals(1000, $voucher->amount);
+        $this->assertNull( $voucher->participants);
+        $this->assertEquals($user->id, $voucher->user_id);
     }
 }


### PR DESCRIPTION
This PR eliminates the hard-coded dependencies on voucher_type_id by introducing a new `source` field with values of refund, partial redemption or purchase.  For source of refund or partial redemption, there will be no voucher type relation.   If source is purchase, the voucher type relation will exist.