### PR TITLE
Add helper to create cartItem from sellable voucher type

### DIFF
--- a/src/Models/VoucherType.php
+++ b/src/Models/VoucherType.php
@@ -108,14 +108,14 @@ class VoucherType extends BaseModel implements Sellable
 
     public function createCartItem(int $locationId, int $quantity = 1): CartItemInterface
     {
-        if (!$this->is_sellable) {
+        if (! $this->is_sellable) {
             throw new UnsupportedVoucherTypeException();
         }
 
         /** @var CartInterface $service */
         $service = findService(CartInterface::class);
 
-       return $service::createItem($this, $this->slug, $this->sell_price, $quantity)
+        return $service::createItem($this, $this->slug, $this->sell_price, $quantity)
             ->setLocationId($locationId);
     }
 


### PR DESCRIPTION
Setup for easier inclusion in Nova purchasing tool.

@drewroberts - may want to consider whether or not staff-bookings package is limited to purchase of only bookings.  If yes, then there will likely need to be a staff-vouchers and staff-products package to allow staff purchase of vouchers and products, possibly with some shared code between them (though, not exactly sure how easy sharing a common base is within a nova tool).   

It could also be three different Nova tools (one for each sellable type), but all provided from by a single package.  Sharing components would definitely be possible with this approach, as well as catering the UI to the type of item being purchased.  Really just need a more inclusive repo name - like staff-purchasing or similar.